### PR TITLE
Correct velocities when this view is moving

### DIFF
--- a/android/src/main/java/com/rnnestedscrollview/ReactNestedScrollView.java
+++ b/android/src/main/java/com/rnnestedscrollview/ReactNestedScrollView.java
@@ -203,6 +203,9 @@ public class ReactNestedScrollView extends NestedScrollView implements ReactClip
       return false;
     }
 
+    boolean result = super.onTouchEvent(ev);
+    ev.setLocation(ev.getRawX(), ev.getRawY());
+
     mVelocityHelper.calculateVelocity(ev);
     int action = ev.getAction() & MotionEvent.ACTION_MASK;
     if (action == MotionEvent.ACTION_UP && mDragging) {
@@ -214,7 +217,7 @@ public class ReactNestedScrollView extends NestedScrollView implements ReactClip
       disableFpsListener();
     }
 
-    return super.onTouchEvent(ev);
+    return result;
   }
 
   @Override


### PR DESCRIPTION
Hey mate,
I just found out that the velocities are not right when this nested scrollview is moving due to the scrolling of parent scrollview. Because the current velocities are calculated based on relative event position. Now I changed it to absolute position.